### PR TITLE
Reduce retained binary memory with range-reader groundwork

### DIFF
--- a/app/src/androidTest/java/com/kyhsgeekcode/disassembler/MainActivityActionViewProjectArchiveIntentFlowTest.kt
+++ b/app/src/androidTest/java/com/kyhsgeekcode/disassembler/MainActivityActionViewProjectArchiveIntentFlowTest.kt
@@ -48,4 +48,18 @@ class MainActivityActionViewProjectArchiveIntentFlowTest {
         assertEquals("ArchiveFixture", ProjectManager.currentProject?.name)
         assertTrue(ProjectManager.currentProject?.sourceFilePath?.endsWith("sourceFilePath") == true)
     }
+
+    @Test
+    fun actionViewProjectArchive_survivesRecreate() {
+        composeRule.waitUntil(timeoutMillis = PROJECT_OPEN_TIMEOUT_MS) {
+            ProjectManager.currentProject?.name == "ArchiveFixture"
+        }
+
+        composeRule.activityRule.scenario.recreate()
+
+        composeRule.waitUntil(timeoutMillis = PROJECT_OPEN_TIMEOUT_MS) {
+            ProjectManager.currentProject?.name == "ArchiveFixture"
+        }
+        composeRule.onNodeWithTag(MainTestTags.EXPORT_PROJECT_BUTTON).assertExists()
+    }
 }

--- a/app/src/androidTest/java/com/kyhsgeekcode/disassembler/MainActivityAdvancedImportCancelFlowTest.kt
+++ b/app/src/androidTest/java/com/kyhsgeekcode/disassembler/MainActivityAdvancedImportCancelFlowTest.kt
@@ -1,0 +1,47 @@
+package com.kyhsgeekcode.disassembler
+
+import android.content.ComponentName
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.kyhsgeekcode.disassembler.ui.MainTestTags
+import com.kyhsgeekcode.filechooser.NewFileChooserActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityAdvancedImportCancelFlowTest {
+    private val projectCleanupRule = ProjectStateCleanupRule()
+    private val preferenceRule = PowerUserModePreferenceRule(powerUserModeEnabled = true)
+    private val intentsRule = InstrumentationIntentsRule()
+    private val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val rules: RuleChain = RuleChain.outerRule(projectCleanupRule)
+        .around(preferenceRule)
+        .around(intentsRule)
+        .around(composeRule)
+
+    @Test
+    fun advancedImportCancel_keepsPowerUserEntryPointsVisible() {
+        intending(
+            hasComponent(
+                ComponentName(
+                    composeRule.activity,
+                    NewFileChooserActivity::class.java
+                )
+            )
+        ).respondWith(createCanceledActivityResult())
+
+        composeRule.onNodeWithTag(MainTestTags.IMPORT_ADVANCED_BUTTON).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(MainTestTags.IMPORT_SAF_BUTTON).assertExists()
+        composeRule.onNodeWithTag(MainTestTags.IMPORT_ADVANCED_BUTTON).assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/kyhsgeekcode/disassembler/MainActivityBinaryDetailExportFlowTest.kt
+++ b/app/src/androidTest/java/com/kyhsgeekcode/disassembler/MainActivityBinaryDetailExportFlowTest.kt
@@ -1,0 +1,83 @@
+package com.kyhsgeekcode.disassembler
+
+import android.content.Intent
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.kyhsgeekcode.disassembler.ui.MainTestTags
+import org.hamcrest.CoreMatchers.allOf
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityBinaryDetailExportFlowTest {
+    private val projectCleanupRule = ProjectStateCleanupRule()
+    private val preferenceRule = PowerUserModePreferenceRule(powerUserModeEnabled = false)
+    private val intentsRule = InstrumentationIntentsRule()
+    private val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val rules: RuleChain = RuleChain.outerRule(projectCleanupRule)
+        .around(preferenceRule)
+        .around(intentsRule)
+        .around(composeRule)
+
+    @Test
+    fun saveDetailsResult_writesTextDocument() {
+        stubSafImport("detail-export-source.apk")
+        val (outputFile, createDocumentResult) = createCreateDocumentResult("binary-details.txt")
+        intending(allOf(hasAction(Intent.ACTION_CREATE_DOCUMENT))).respondWith(createDocumentResult)
+
+        openProjectAndDetailTab()
+        composeRule.onNodeWithTag(MainTestTags.SAVE_DETAILS_BUTTON).performClick()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            outputFile.length() > 0L
+        }
+
+        assertTrue(outputFile.readText().contains("File Size:"))
+    }
+
+    @Test
+    fun saveDetailsCancel_keepsProjectOpen() {
+        stubSafImport("detail-export-cancel-source.apk")
+        intending(allOf(hasAction(Intent.ACTION_CREATE_DOCUMENT))).respondWith(createCanceledActivityResult())
+
+        openProjectAndDetailTab()
+        composeRule.onNodeWithTag(MainTestTags.SAVE_DETAILS_BUTTON).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(MainTestTags.SAVE_DETAILS_BUTTON).assertExists()
+        composeRule.onNodeWithTag(MainTestTags.EXPORT_PROJECT_BUTTON).assertExists()
+    }
+
+    private fun stubSafImport(displayName: String) {
+        intending(
+            allOf(
+                hasAction(Intent.ACTION_OPEN_DOCUMENT)
+            )
+        ).respondWith(
+            createOpenDocumentResult(
+                displayName = displayName,
+                content = "apk-content".encodeToByteArray()
+            )
+        )
+    }
+
+    private fun openProjectAndDetailTab() {
+        composeRule.onNodeWithTag(MainTestTags.IMPORT_SAF_BUTTON).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(MainTestTags.EXPORT_PROJECT_BUTTON)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(MainTestTags.BINARY_TAB_DETAIL).performClick()
+        composeRule.onNodeWithTag(MainTestTags.SAVE_DETAILS_BUTTON).assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/kyhsgeekcode/disassembler/MainActivitySafImportCancelFlowTest.kt
+++ b/app/src/androidTest/java/com/kyhsgeekcode/disassembler/MainActivitySafImportCancelFlowTest.kt
@@ -1,0 +1,44 @@
+package com.kyhsgeekcode.disassembler
+
+import android.content.Intent
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.kyhsgeekcode.disassembler.ui.MainTestTags
+import org.hamcrest.CoreMatchers.allOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivitySafImportCancelFlowTest {
+    private val projectCleanupRule = ProjectStateCleanupRule()
+    private val preferenceRule = PowerUserModePreferenceRule(powerUserModeEnabled = false)
+    private val intentsRule = InstrumentationIntentsRule()
+    private val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val rules: RuleChain = RuleChain.outerRule(projectCleanupRule)
+        .around(preferenceRule)
+        .around(intentsRule)
+        .around(composeRule)
+
+    @Test
+    fun safImportCancel_keepsStandardEntryPointVisible() {
+        intending(
+            allOf(
+                hasAction(Intent.ACTION_OPEN_DOCUMENT)
+            )
+        ).respondWith(createCanceledActivityResult())
+
+        composeRule.onNodeWithTag(MainTestTags.IMPORT_SAF_BUTTON).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(MainTestTags.IMPORT_SAF_BUTTON).assertExists()
+        composeRule.onNodeWithTag(MainTestTags.IMPORT_ADVANCED_BUTTON).assertDoesNotExist()
+    }
+}

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/AbstractFile.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/AbstractFile.kt
@@ -78,6 +78,16 @@ abstract class AbstractFile : Closeable {
         private const val TAG = "AbstractFile"
 
         @JvmStatic
+        internal fun readFileContentsForParsing(
+            file: File,
+            readerFactory: (File) -> BinaryRangeReader = ::FileChannelBinaryRangeReader
+        ): ByteArray {
+            return readerFactory(file).use { reader ->
+                reader.readFully()
+            }
+        }
+
+        @JvmStatic
         @Throws(IOException::class)
         fun createInstance(file: File): AbstractFile {
             // file을 읽던가 mainactivity의 코드를 잘 가져와서 AbstractFile을 만든다.
@@ -89,7 +99,7 @@ abstract class AbstractFile : Closeable {
             // 그리고 AfterReadFully 함수는 없어질지도 모른다!
             // 그러면 중복코드도 사라짐
             // 행복회로
-            val content = file.readBytes()
+            val content = readFileContentsForParsing(file)
             if (file.path.endsWith("assets/bin/Data/Managed/Assembly-CSharp.dll")) { // Unity C# dll file
                 Logger.v(TAG, "Found C# unity dll")
                 try {

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/AbstractFile.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/AbstractFile.kt
@@ -21,7 +21,7 @@ abstract class AbstractFile : Closeable {
     }
 
     override fun toString(): String {
-        if (fileContents == null) {
+        if (!::fileContents.isInitialized) {
             return "The file has not been configured. You should setup manually in the first page before you can see the details."
         }
         val builder = StringBuilder(
@@ -29,7 +29,7 @@ abstract class AbstractFile : Closeable {
                     System.lineSeparator() else ""
         )
         builder.append(/*R.getString(R.string.FileSize)*/"File Size:")
-            .append(Integer.toHexString(fileContents.size))
+            .append(java.lang.Long.toHexString(getBinaryLength()))
             .append(ls)
         builder.append(appCtx.getString(R.string.FoffsCS))
             .append(java.lang.Long.toHexString(codeSectionBase))
@@ -74,6 +74,10 @@ abstract class AbstractFile : Closeable {
     @JvmField
     var path = ""
 
+    open fun getBinaryContents(): ByteArray = fileContents
+
+    open fun getBinaryLength(): Long = getBinaryContents().size.toLong()
+
     companion object {
         private const val TAG = "AbstractFile"
 
@@ -88,6 +92,31 @@ abstract class AbstractFile : Closeable {
         }
 
         @JvmStatic
+        internal fun detectBinaryContainerFormat(
+            file: File,
+            readerFactory: (File) -> BinaryRangeReader = ::FileChannelBinaryRangeReader
+        ): BinaryContainerFormat {
+            val header = readerFactory(file).use { reader ->
+                reader.read(offset = 0, length = 4)
+            }
+            if (header.size >= 4 &&
+                header[0] == 0x7F.toByte() &&
+                header[1] == 'E'.code.toByte() &&
+                header[2] == 'L'.code.toByte() &&
+                header[3] == 'F'.code.toByte()
+            ) {
+                return BinaryContainerFormat.ELF
+            }
+            if (header.size >= 2 &&
+                header[0] == 'M'.code.toByte() &&
+                header[1] == 'Z'.code.toByte()
+            ) {
+                return BinaryContainerFormat.PE
+            }
+            return BinaryContainerFormat.RAW
+        }
+
+        @JvmStatic
         @Throws(IOException::class)
         fun createInstance(file: File): AbstractFile {
             // file을 읽던가 mainactivity의 코드를 잘 가져와서 AbstractFile을 만든다.
@@ -99,8 +128,8 @@ abstract class AbstractFile : Closeable {
             // 그리고 AfterReadFully 함수는 없어질지도 모른다!
             // 그러면 중복코드도 사라짐
             // 행복회로
-            val content = readFileContentsForParsing(file)
             if (file.path.endsWith("assets/bin/Data/Managed/Assembly-CSharp.dll")) { // Unity C# dll file
+                val content = readFileContentsForParsing(file)
                 Logger.v(TAG, "Found C# unity dll")
                 try {
                     val facileReflector = Facile.load(file.path)
@@ -119,30 +148,40 @@ abstract class AbstractFile : Closeable {
                 } catch (e: SizeMismatchException) {
                     e.printStackTrace()
                 }
-            } else {
-                return try {
-                    ElfFile(file, content)
-                } catch (e: Exception) { // not an elf file. try PE parser
-                    Timber.d(e, "Fail elfutil")
+            }
+            return when (detectBinaryContainerFormat(file)) {
+                BinaryContainerFormat.ELF -> {
+                    val content = readFileContentsForParsing(file)
+                    try {
+                        ElfFile(file, content)
+                    } catch (e: Exception) {
+                        Timber.d(e, "Fail elfutil")
+                        RawFile(file, content)
+                    }
+                }
+
+                BinaryContainerFormat.PE -> {
+                    val content = readFileContentsForParsing(file)
                     try {
                         PEFile(file, content)
                     } catch (f: NotThisFormatException) {
                         Timber.e(f, "Not this format exception")
                         RawFile(file, content)
-                        // AllowRawSetup();
-// failed to parse the file. please setup manually.
-                    } catch (f: RuntimeException) { // AlertError("Failed to parse the file. Please setup manually. Sending an error report, the file being analyzed can be attached.", f);
+                    } catch (f: RuntimeException) {
                         Timber.e(f, "Not this format exception")
                         RawFile(file, content)
-                        // AllowRawSetup();
-                    } catch (g: Exception) { // AlertError("Unexpected exception: failed to parse the file. please setup manually.", g);
+                    } catch (g: Exception) {
                         Timber.e(g, "What the exception")
                         RawFile(file, content)
-                        // AllowRawSetup();
+                    }
+                }
+
+                BinaryContainerFormat.RAW -> {
+                    RawFile(file, filecontent = null) {
+                        readFileContentsForParsing(file)
                     }
                 }
             }
-            return RawFile(file, content)
 //            return null
         }
     }

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/AbstractFile.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/AbstractFile.kt
@@ -166,7 +166,9 @@ abstract class AbstractFile : Closeable {
                 BinaryContainerFormat.PE -> {
                     val content = readFileContentsForParsing(file)
                     try {
-                        PEFile(file, content)
+                        PEFile(file, content, BinaryContentLoader {
+                            readFileContentsForParsing(file)
+                        })
                     } catch (f: NotThisFormatException) {
                         Timber.e(f, "Not this format exception")
                         RawFile(file, content)

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/AbstractFile.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/AbstractFile.kt
@@ -151,12 +151,15 @@ abstract class AbstractFile : Closeable {
             }
             return when (detectBinaryContainerFormat(file)) {
                 BinaryContainerFormat.ELF -> {
-                    val content = readFileContentsForParsing(file)
                     try {
-                        ElfFile(file, content)
+                        ElfFile(file, filec = null, deferredContentLoader = BinaryContentLoader {
+                            readFileContentsForParsing(file)
+                        })
                     } catch (e: Exception) {
                         Timber.d(e, "Fail elfutil")
-                        RawFile(file, content)
+                        RawFile(file, filecontent = null) {
+                            readFileContentsForParsing(file)
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/BinaryContainerFormat.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/BinaryContainerFormat.kt
@@ -1,0 +1,7 @@
+package com.kyhsgeekcode.disassembler.files
+
+enum class BinaryContainerFormat {
+    ELF,
+    PE,
+    RAW,
+}

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/BinaryContentLoader.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/BinaryContentLoader.kt
@@ -1,0 +1,5 @@
+package com.kyhsgeekcode.disassembler.files
+
+fun interface BinaryContentLoader {
+    fun load(): ByteArray
+}

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/BinaryRangeReader.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/BinaryRangeReader.kt
@@ -1,0 +1,11 @@
+package com.kyhsgeekcode.disassembler.files
+
+import java.io.Closeable
+
+interface BinaryRangeReader : Closeable {
+    val size: Long
+
+    fun read(offset: Long, length: Int): ByteArray
+
+    fun readFully(): ByteArray
+}

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/DeferredFileBackedBinaryContent.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/DeferredFileBackedBinaryContent.kt
@@ -1,0 +1,25 @@
+package com.kyhsgeekcode.disassembler.files
+
+import java.io.File
+
+class DeferredFileBackedBinaryContent(
+    private val file: File,
+    initialContent: ByteArray? = null,
+    private val loader: BinaryContentLoader? = null,
+) {
+    private var loadedContent: ByteArray? = initialContent
+
+    fun contents(): ByteArray {
+        val existing = loadedContent
+        if (existing != null) {
+            return existing
+        }
+        val loaded = loader?.load() ?: file.readBytes()
+        loadedContent = loaded
+        return loaded
+    }
+
+    fun length(): Long {
+        return loadedContent?.size?.toLong() ?: file.length()
+    }
+}

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/ElfFile.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/ElfFile.kt
@@ -10,7 +10,18 @@ import java.io.IOException
 import java.nio.ByteBuffer
 import java.util.*
 
-class ElfFile(file: File, filec: ByteArray) : AbstractFile() {
+class ElfFile(
+    private val file: File,
+    filec: ByteArray? = null,
+    deferredContentLoader: BinaryContentLoader? = null,
+) : AbstractFile() {
+    private var contentLoaded = filec != null
+    private val binaryContent = DeferredFileBackedBinaryContent(
+        file = file,
+        initialContent = filec,
+        loader = deferredContentLoader,
+    )
+
     fun getPltIndexFromJumpAddress(address: Long): Int {
         Log.d(TAG, "GetPltIndexFromJumpAddress $address")
         pltRange?.let {
@@ -51,6 +62,18 @@ class ElfFile(file: File, filec: ByteArray) : AbstractFile() {
     @Throws(IOException::class)
     override fun close() {
         elf.close()
+    }
+
+    override fun getBinaryContents(): ByteArray {
+        if (!contentLoaded) {
+            fileContents = binaryContent.contents()
+            contentLoaded = true
+        }
+        return fileContents
+    }
+
+    override fun getBinaryLength(): Long {
+        return if (contentLoaded) fileContents.size.toLong() else binaryContent.length()
     }
 
     override fun toString(): String {
@@ -515,8 +538,9 @@ class ElfFile(file: File, filec: ByteArray) : AbstractFile() {
     init {
         elf = Elf(file)
         path = file.path
-        fileContents = filec
+        if (filec != null) {
+            fileContents = filec
+        }
         afterConstructor()
     }
 }
-

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/FileChannelBinaryRangeReader.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/FileChannelBinaryRangeReader.kt
@@ -1,0 +1,40 @@
+package com.kyhsgeekcode.disassembler.files
+
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.StandardOpenOption
+import kotlin.math.min
+
+class FileChannelBinaryRangeReader(file: File) : BinaryRangeReader {
+    private val channel = FileChannel.open(file.toPath(), StandardOpenOption.READ)
+
+    override val size: Long
+        get() = channel.size()
+
+    override fun read(offset: Long, length: Int): ByteArray {
+        require(offset >= 0) { "offset must be non-negative" }
+        require(length >= 0) { "length must be non-negative" }
+        if (length == 0 || offset >= size) {
+            return ByteArray(0)
+        }
+        val readableLength = min(length.toLong(), size - offset).toInt()
+        val buffer = ByteBuffer.allocate(readableLength)
+        channel.read(buffer, offset)
+        return buffer.array()
+    }
+
+    override fun readFully(): ByteArray {
+        if (size == 0L) {
+            return ByteArray(0)
+        }
+        require(size <= Int.MAX_VALUE) {
+            "File is too large to fit into a ByteArray: $size bytes"
+        }
+        return read(offset = 0, length = size.toInt())
+    }
+
+    override fun close() {
+        channel.close()
+    }
+}

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/PEFile.java
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/PEFile.java
@@ -30,9 +30,22 @@ import timber.log.Timber;
 public class PEFile extends AbstractFile {
     PE pe;
     ArrayList<TLS> tlss = new ArrayList<>();
+    private final DeferredFileBackedBinaryContent binaryContent;
+    private boolean contentLoaded;
 
     public PEFile(File file, byte[] filec) throws IOException, NotThisFormatException {
+        this(file, filec, null);
+    }
+
+    public PEFile(File file, byte[] filec, BinaryContentLoader deferredContentLoader) throws IOException, NotThisFormatException {
         path = file.getPath();
+        byte[] parsingBytes = filec != null ? filec : loadBinaryContents(file, deferredContentLoader);
+        binaryContent = new DeferredFileBackedBinaryContent(
+                file,
+                deferredContentLoader == null ? parsingBytes : null,
+                deferredContentLoader
+        );
+        contentLoaded = deferredContentLoader == null;
         try {
             pe = PEParser.parse(file);
         } catch (NegativeArraySizeException e) {
@@ -54,7 +67,6 @@ public class PEFile extends AbstractFile {
         setCodeSectionLimit(getCodeSectionBase() + oph.getSizeOfCode());
         setCodeVirtAddr(oph.getImageBase() + getCodeSectionBase());
         setEntryPoint(oph.getAddressOfEntryPoint());
-        fileContents = filec;
 
         getExportSymbols().clear();
         getImportSymbols().clear();
@@ -68,11 +80,11 @@ public class PEFile extends AbstractFile {
             if (ide == null)
                 continue;//null dll
 
-            String dllname = Elf.getZString(filec, rvc.convertVirtualAddressToRawDataPointer(ide.getNameRVA()));//idir.getName(i);//get dll name? !! Not implemented method!!!!
+            String dllname = Elf.getZString(parsingBytes, rvc.convertVirtualAddressToRawDataPointer(ide.getNameRVA()));//idir.getName(i);//get dll name? !! Not implemented method!!!!
             Timber.v(dllname);
             long originalFirstThunkRaw = rvc.convertVirtualAddressToRawDataPointer(ide.getImportLookupTableRVA());//OriginalFirstThunk
             long firstThunkRaw = rvc.convertVirtualAddressToRawDataPointer(ide.getImportAddressTableRVA());
-            ByteBuffer buf = ByteBuffer.wrap(filec, (int) originalFirstThunkRaw, (int) (filec.length - originalFirstThunkRaw)).order(ByteOrder.LITTLE_ENDIAN);
+            ByteBuffer buf = ByteBuffer.wrap(parsingBytes, (int) originalFirstThunkRaw, (int) (parsingBytes.length - originalFirstThunkRaw)).order(ByteOrder.LITTLE_ENDIAN);
             int off = 0;
             //Read by dword!
             for (; ; ) {
@@ -89,7 +101,7 @@ public class PEFile extends AbstractFile {
                     //CHAR name[1];
 					/*ByteBuffer INT=ByteBuffer.wrap(filec,(int)data,(int)(filec.length-data));
 					 INT.getShort();*/
-                    String funcname = Elf.getZString(filec, rvc.convertVirtualAddressToRawDataPointer((int) data) + 2);
+                    String funcname = Elf.getZString(parsingBytes, rvc.convertVirtualAddressToRawDataPointer((int) data) + 2);
                     //Log.v(TAG,dllname+"."+funcname);
                     importSymbol.owner = dllname;
                     importSymbol.name = funcname;
@@ -107,8 +119,8 @@ public class PEFile extends AbstractFile {
             long funcAddrRaw = rvc.convertVirtualAddressToRawDataPointer((int) edir.getExportAddressTableRVA());
             long funcNameRaw = rvc.convertVirtualAddressToRawDataPointer((int) edir.getNamePointerRVA());
             long funcOrdinalRaw = rvc.convertVirtualAddressToRawDataPointer((int) edir.getOrdinalTableRVA());
-            ByteBuffer funcnamePointers = ByteBuffer.wrap(filec, (int) funcNameRaw, (int) (filec.length - funcNameRaw)).order(ByteOrder.LITTLE_ENDIAN);//len eq num of name
-            ByteBuffer funcOrdinalPointers = ByteBuffer.wrap(filec, (int) funcOrdinalRaw, (int) (filec.length - funcOrdinalRaw)).order(ByteOrder.LITTLE_ENDIAN);//len eq num of name
+            ByteBuffer funcnamePointers = ByteBuffer.wrap(parsingBytes, (int) funcNameRaw, (int) (parsingBytes.length - funcNameRaw)).order(ByteOrder.LITTLE_ENDIAN);//len eq num of name
+            ByteBuffer funcOrdinalPointers = ByteBuffer.wrap(parsingBytes, (int) funcOrdinalRaw, (int) (parsingBytes.length - funcOrdinalRaw)).order(ByteOrder.LITTLE_ENDIAN);//len eq num of name
             int ordinalbase = (int) edir.getOrdinalBase();
             Timber.v("OrdinalBase=" + ordinalbase);
             //RVAConverter rvc=pe.getSectionTable().getRVAConverter();
@@ -116,7 +128,7 @@ public class PEFile extends AbstractFile {
             {
                 Symbol sym = new Symbol();
                 try {
-                    sym.name = Elf.getZString(filec, rvc.convertVirtualAddressToRawDataPointer(funcnamePointers.getInt() & 0x7FFFFFFF));
+                    sym.name = Elf.getZString(parsingBytes, rvc.convertVirtualAddressToRawDataPointer(funcnamePointers.getInt() & 0x7FFFFFFF));
                 } catch (StringIndexOutOfBoundsException e) {
                     Timber.e(e);
                     sym.name = "ordinal?";
@@ -126,7 +138,7 @@ public class PEFile extends AbstractFile {
                 int ordinal = funcOrdinalPointers.getShort() & 0x7FFF;
                 long addraddr = funcAddrRaw + 4 * (ordinal - ordinalbase);
                 Timber.v("addraddr=" + addraddr);
-                sym.st_value = ByteBuffer.wrap(filec, (int) addraddr, (int) (filec.length - addraddr)).order(ByteOrder.LITTLE_ENDIAN).getInt() & 0x7FFFFFFF;
+                sym.st_value = ByteBuffer.wrap(parsingBytes, (int) addraddr, (int) (parsingBytes.length - addraddr)).order(ByteOrder.LITTLE_ENDIAN).getInt() & 0x7FFFFFFF;
                 Timber.v(sym.toString());
                 sym.type = Symbol.Type.STT_FUNC;
                 sym.bind = Symbol.Bind.STB_GLOBAL;
@@ -161,6 +173,27 @@ public class PEFile extends AbstractFile {
             Timber.d(e, "Error parsing PE File");
         }
 
+    }
+
+    private static byte[] loadBinaryContents(File file, BinaryContentLoader deferredContentLoader) throws IOException {
+        if (deferredContentLoader != null) {
+            return deferredContentLoader.load();
+        }
+        return java.nio.file.Files.readAllBytes(file.toPath());
+    }
+
+    @Override
+    public byte[] getBinaryContents() {
+        if (!contentLoaded) {
+            fileContents = binaryContent.contents();
+            contentLoaded = true;
+        }
+        return fileContents;
+    }
+
+    @Override
+    public long getBinaryLength() {
+        return contentLoaded ? fileContents.length : binaryContent.length();
     }
 
     //https://docs.microsoft.com/ko-kr/windows/desktop/api/winnt/ns-winnt-_image_file_header

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/RawFile.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/RawFile.kt
@@ -2,9 +2,35 @@ package com.kyhsgeekcode.disassembler.files
 
 import java.io.File
 
-class RawFile(file: File, filecontent: ByteArray?) : AbstractFile() {
+class RawFile(
+    private val file: File,
+    filecontent: ByteArray?,
+    private val deferredContentLoader: (() -> ByteArray)? = null
+) : AbstractFile() {
+    private var contentLoaded = false
+
     init {
-        fileContents = filecontent!!
+        if (filecontent != null) {
+            fileContents = filecontent
+            contentLoaded = true
+        }
         path = file.path
+    }
+
+    override fun getBinaryContents(): ByteArray {
+        if (!contentLoaded) {
+            fileContents = deferredContentLoader?.invoke()
+                ?: throw IllegalStateException("No file contents available for raw binary")
+            contentLoaded = true
+        }
+        return fileContents
+    }
+
+    override fun getBinaryLength(): Long {
+        return if (contentLoaded) {
+            fileContents.size.toLong()
+        } else {
+            file.length()
+        }
     }
 }

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/files/RawFile.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/files/RawFile.kt
@@ -3,34 +3,30 @@ package com.kyhsgeekcode.disassembler.files
 import java.io.File
 
 class RawFile(
-    private val file: File,
+    file: File,
     filecontent: ByteArray?,
     private val deferredContentLoader: (() -> ByteArray)? = null
 ) : AbstractFile() {
-    private var contentLoaded = false
+    private var contentLoaded = filecontent != null
+    private val binaryContent = DeferredFileBackedBinaryContent(
+        file = file,
+        initialContent = filecontent,
+        loader = deferredContentLoader?.let { BinaryContentLoader { it() } },
+    )
 
     init {
-        if (filecontent != null) {
-            fileContents = filecontent
-            contentLoaded = true
-        }
         path = file.path
     }
 
     override fun getBinaryContents(): ByteArray {
         if (!contentLoaded) {
-            fileContents = deferredContentLoader?.invoke()
-                ?: throw IllegalStateException("No file contents available for raw binary")
+            fileContents = binaryContent.contents()
             contentLoaded = true
         }
         return fileContents
     }
 
     override fun getBinaryLength(): Long {
-        return if (contentLoaded) {
-            fileContents.size.toLong()
-        } else {
-            file.length()
-        }
+        return if (contentLoaded) fileContents.size.toLong() else binaryContent.length()
     }
 }

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/ui/MainTestTags.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/ui/MainTestTags.kt
@@ -6,4 +6,6 @@ object MainTestTags {
     const val EXPORT_PROJECT_BUTTON = "export_project_button"
     const val COPY_DIALOG_YES_BUTTON = "copy_dialog_yes_button"
     const val COPY_DIALOG_NO_BUTTON = "copy_dialog_no_button"
+    const val BINARY_TAB_DETAIL = "binary_tab_detail"
+    const val SAVE_DETAILS_BUTTON = "save_details_button"
 }

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/ui/tabs/BinaryDetailTab.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/ui/tabs/BinaryDetailTab.kt
@@ -14,12 +14,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.kyhsgeekcode.disassembler.R
 import com.kyhsgeekcode.disassembler.exporting.buildBinaryDetailsExportFileName
 import com.kyhsgeekcode.disassembler.exporting.writeTextDocument
 import com.kyhsgeekcode.disassembler.files.AbstractFile
+import com.kyhsgeekcode.disassembler.ui.MainTestTags
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -82,7 +84,9 @@ fun BinaryDetailTabContent(data: AbstractFile) {
             .padding(10.dp)
     ) {
         Button(
-            modifier = Modifier.padding(bottom = 12.dp),
+            modifier = Modifier
+                .padding(bottom = 12.dp)
+                .testTag(MainTestTags.SAVE_DETAILS_BUTTON),
             onClick = {
                 exportDetailsLauncher.launch(buildBinaryDetailsExportFileName(data.path))
             }

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/ui/tabs/BinaryDisasmTab.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/ui/tabs/BinaryDisasmTab.kt
@@ -40,6 +40,8 @@ sealed class ShowCommentEditDialog {
 private const val INSERT_COUNT = 160
 
 class BinaryDisasmData(val file: AbstractFile, val handle: Int) : PreparedTabData() {
+    private val binaryContents: ByteArray by lazy { file.getBinaryContents() }
+
     private val addressToListItem = LongSparseArray<DisassemblyListItem>()
     var positionToAddress = SparseArray<Long>()
     var writep = 0
@@ -102,9 +104,9 @@ class BinaryDisasmData(val file: AbstractFile, val handle: Int) : PreparedTabDat
         if (currentAddress.value == 0L)
             _currentAddress.value = address + file.codeSectionBase - file.codeVirtAddr
         val newItems = assemblyProvider.getSome(
-            file.fileContents,
+            binaryContents,
             address + file.codeSectionBase - file.codeVirtAddr /*address-file.codeVirtualAddress*/,
-            file.fileContents.size.toLong(),
+            file.getBinaryLength(),
             address,
             INSERT_COUNT
         )
@@ -155,7 +157,7 @@ class BinaryDisasmData(val file: AbstractFile, val handle: Int) : PreparedTabDat
     }
 
     private fun isValidAddress(address: Long): Boolean {
-        return if (address > file.fileContents.size + file.codeVirtAddr) false else address >= 0
+        return if (address > file.getBinaryLength() + file.codeVirtAddr) false else address >= 0
     }
 
     fun setCurrentAddressByFirstItemIndex(firstVisibleItemIndex: Int) {

--- a/app/src/main/java/com/kyhsgeekcode/disassembler/ui/tabs/BinaryTab.kt
+++ b/app/src/main/java/com/kyhsgeekcode/disassembler/ui/tabs/BinaryTab.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import com.kyhsgeekcode.disassembler.MainActivity
 import com.kyhsgeekcode.disassembler.R
@@ -225,6 +226,7 @@ fun OpenedBinaryTabs(data: BinaryTabData, viewModel: MainViewModel) {
         ) {
             titles.forEachIndexed { index, title ->
                 Tab(
+                    modifier = Modifier.testTag(binaryTabTestTag(tabs.value[index].tabKind)),
                     text = { Text(title) },
                     selected = currentTabIndex.value == index,
                     onClick = { data.setCurrentTabByIndex(index) }
@@ -232,6 +234,13 @@ fun OpenedBinaryTabs(data: BinaryTabData, viewModel: MainViewModel) {
             }
         }
         BinaryTabContent(currentTabIndex.value, data, viewModel)
+    }
+}
+
+private fun binaryTabTestTag(tabKind: BinaryTabKind): String {
+    return when (tabKind) {
+        is BinaryTabKind.BinaryDetail -> com.kyhsgeekcode.disassembler.ui.MainTestTags.BINARY_TAB_DETAIL
+        else -> "binary_tab_${tabKind::class.simpleName}"
     }
 }
 

--- a/app/src/test/java/com/kyhsgeekcode/disassembler/files/AbstractFileReaderBridgeTest.kt
+++ b/app/src/test/java/com/kyhsgeekcode/disassembler/files/AbstractFileReaderBridgeTest.kt
@@ -1,0 +1,46 @@
+package com.kyhsgeekcode.disassembler.files
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertTrue
+
+class AbstractFileReaderBridgeTest {
+    @Test
+    fun `readFileContentsForParsing reads through range reader and closes it`() {
+        val expected = byteArrayOf(1, 2, 3, 4)
+        val fakeReader = FakeBinaryRangeReader(expected)
+
+        val actual = AbstractFile.readFileContentsForParsing(createTempFileWithBytes(expected)) { fakeReader }
+
+        assertContentEquals(expected, actual)
+        assertTrue(fakeReader.closed)
+        assertTrue(fakeReader.readFullyCalled)
+    }
+
+    private fun createTempFileWithBytes(bytes: ByteArray) =
+        kotlin.io.path.createTempFile("abstract-file-reader", ".bin").toFile().apply {
+            writeBytes(bytes)
+            deleteOnExit()
+        }
+
+    private class FakeBinaryRangeReader(private val bytes: ByteArray) : BinaryRangeReader {
+        var closed = false
+        var readFullyCalled = false
+
+        override val size: Long
+            get() = bytes.size.toLong()
+
+        override fun read(offset: Long, length: Int): ByteArray {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        override fun readFully(): ByteArray {
+            readFullyCalled = true
+            return bytes
+        }
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/app/src/test/java/com/kyhsgeekcode/disassembler/files/BinaryContainerFormatDetectionTest.kt
+++ b/app/src/test/java/com/kyhsgeekcode/disassembler/files/BinaryContainerFormatDetectionTest.kt
@@ -1,0 +1,52 @@
+package com.kyhsgeekcode.disassembler.files
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BinaryContainerFormatDetectionTest {
+    @Test
+    fun `detectBinaryContainerFormat recognizes ELF headers`() {
+        val format = AbstractFile.detectBinaryContainerFormat(
+            createTempFileWithBytes(byteArrayOf(0x7F, 'E'.code.toByte(), 'L'.code.toByte(), 'F'.code.toByte()))
+        ) { _ -> FakeHeaderReader(byteArrayOf(0x7F, 'E'.code.toByte(), 'L'.code.toByte(), 'F'.code.toByte())) }
+
+        assertEquals(BinaryContainerFormat.ELF, format)
+    }
+
+    @Test
+    fun `detectBinaryContainerFormat recognizes MZ headers as PE`() {
+        val format = AbstractFile.detectBinaryContainerFormat(
+            createTempFileWithBytes(byteArrayOf('M'.code.toByte(), 'Z'.code.toByte(), 0x00, 0x00))
+        ) { _ -> FakeHeaderReader(byteArrayOf('M'.code.toByte(), 'Z'.code.toByte(), 0x00, 0x00)) }
+
+        assertEquals(BinaryContainerFormat.PE, format)
+    }
+
+    @Test
+    fun `detectBinaryContainerFormat falls back to RAW for unknown headers`() {
+        val format = AbstractFile.detectBinaryContainerFormat(
+            createTempFileWithBytes(byteArrayOf(0x00, 0x01, 0x02, 0x03))
+        ) { _ -> FakeHeaderReader(byteArrayOf(0x00, 0x01, 0x02, 0x03)) }
+
+        assertEquals(BinaryContainerFormat.RAW, format)
+    }
+
+    private fun createTempFileWithBytes(bytes: ByteArray) =
+        kotlin.io.path.createTempFile("binary-format", ".bin").toFile().apply {
+            writeBytes(bytes)
+            deleteOnExit()
+        }
+
+    private class FakeHeaderReader(private val header: ByteArray) : BinaryRangeReader {
+        override val size: Long
+            get() = header.size.toLong()
+
+        override fun read(offset: Long, length: Int): ByteArray {
+            return header.copyOf(minOf(length, header.size))
+        }
+
+        override fun readFully(): ByteArray = header
+
+        override fun close() = Unit
+    }
+}

--- a/app/src/test/java/com/kyhsgeekcode/disassembler/files/DeferredFileBackedBinaryContentTest.kt
+++ b/app/src/test/java/com/kyhsgeekcode/disassembler/files/DeferredFileBackedBinaryContentTest.kt
@@ -1,0 +1,57 @@
+package com.kyhsgeekcode.disassembler.files
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class DeferredFileBackedBinaryContentTest {
+    @Test
+    fun `contents returns initial content without invoking loader`() {
+        var loadCount = 0
+        val file = createTempFileWithBytes(byteArrayOf(1, 2, 3))
+        val content = DeferredFileBackedBinaryContent(
+            file = file,
+            initialContent = byteArrayOf(4, 5, 6),
+            loader = BinaryContentLoader {
+                loadCount++
+                byteArrayOf(7, 8, 9)
+            }
+        )
+
+        assertContentEquals(byteArrayOf(4, 5, 6), content.contents())
+        assertEquals(0, loadCount)
+    }
+
+    @Test
+    fun `contents loads from loader only once when initial content is absent`() {
+        var loadCount = 0
+        val file = createTempFileWithBytes(byteArrayOf(1, 2, 3))
+        val content = DeferredFileBackedBinaryContent(
+            file = file,
+            loader = BinaryContentLoader {
+                loadCount++
+                byteArrayOf(9, 8, 7)
+            }
+        )
+
+        assertContentEquals(byteArrayOf(9, 8, 7), content.contents())
+        assertContentEquals(byteArrayOf(9, 8, 7), content.contents())
+        assertEquals(1, loadCount)
+    }
+
+    @Test
+    fun `length uses file size before content is loaded`() {
+        val file = createTempFileWithBytes(byteArrayOf(1, 2, 3, 4, 5))
+        val content = DeferredFileBackedBinaryContent(file = file)
+
+        assertEquals(5L, content.length())
+    }
+
+    private fun createTempFileWithBytes(bytes: ByteArray): File {
+        return kotlin.io.path.createTempFile("deferred-content", ".bin").toFile().apply {
+            writeBytes(bytes)
+            deleteOnExit()
+        }
+    }
+}

--- a/app/src/test/java/com/kyhsgeekcode/disassembler/files/FileChannelBinaryRangeReaderTest.kt
+++ b/app/src/test/java/com/kyhsgeekcode/disassembler/files/FileChannelBinaryRangeReaderTest.kt
@@ -1,0 +1,54 @@
+package com.kyhsgeekcode.disassembler.files
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FileChannelBinaryRangeReaderTest {
+    @Test
+    fun readReturnsRequestedRange() {
+        val file = createTempFileWithBytes(byteArrayOf(0x10, 0x11, 0x12, 0x13, 0x14))
+
+        FileChannelBinaryRangeReader(file).use { reader ->
+            assertContentEquals(byteArrayOf(0x11, 0x12, 0x13), reader.read(offset = 1, length = 3))
+        }
+    }
+
+    @Test
+    fun readClampsAtEndOfFile() {
+        val file = createTempFileWithBytes(byteArrayOf(0x20, 0x21, 0x22))
+
+        FileChannelBinaryRangeReader(file).use { reader ->
+            assertContentEquals(byteArrayOf(0x21, 0x22), reader.read(offset = 1, length = 10))
+        }
+    }
+
+    @Test
+    fun readReturnsEmptyArrayPastEndOfFile() {
+        val file = createTempFileWithBytes(byteArrayOf(0x30, 0x31))
+
+        FileChannelBinaryRangeReader(file).use { reader ->
+            assertTrue(reader.read(offset = 5, length = 4).isEmpty())
+        }
+    }
+
+    @Test
+    fun readFullyReturnsEntireFile() {
+        val bytes = byteArrayOf(0x40, 0x41, 0x42, 0x43)
+        val file = createTempFileWithBytes(bytes)
+
+        FileChannelBinaryRangeReader(file).use { reader ->
+            assertEquals(bytes.size.toLong(), reader.size)
+            assertContentEquals(bytes, reader.readFully())
+        }
+    }
+
+    private fun createTempFileWithBytes(bytes: ByteArray): File {
+        return kotlin.io.path.createTempFile("range-reader", ".bin").toFile().apply {
+            writeBytes(bytes)
+            deleteOnExit()
+        }
+    }
+}

--- a/app/src/test/java/com/kyhsgeekcode/disassembler/files/RawFileLazyContentTest.kt
+++ b/app/src/test/java/com/kyhsgeekcode/disassembler/files/RawFileLazyContentTest.kt
@@ -1,0 +1,37 @@
+package com.kyhsgeekcode.disassembler.files
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class RawFileLazyContentTest {
+    @Test
+    fun `binaryLength uses file size before contents are loaded`() {
+        val file = createTempFileWithBytes(byteArrayOf(1, 2, 3, 4, 5))
+
+        val rawFile = RawFile(file, filecontent = null) { byteArrayOf(9, 9, 9) }
+
+        assertEquals(5L, rawFile.getBinaryLength())
+    }
+
+    @Test
+    fun `getBinaryContents loads deferred contents once`() {
+        val file = createTempFileWithBytes(byteArrayOf(1, 2, 3))
+        var loadCount = 0
+        val rawFile = RawFile(file, filecontent = null) {
+            loadCount++
+            byteArrayOf(4, 5, 6)
+        }
+
+        assertContentEquals(byteArrayOf(4, 5, 6), rawFile.getBinaryContents())
+        assertContentEquals(byteArrayOf(4, 5, 6), rawFile.getBinaryContents())
+        assertEquals(1, loadCount)
+        assertEquals(3L, rawFile.getBinaryLength())
+    }
+
+    private fun createTempFileWithBytes(bytes: ByteArray) =
+        kotlin.io.path.createTempFile("raw-file", ".bin").toFile().apply {
+            writeBytes(bytes)
+            deleteOnExit()
+        }
+}


### PR DESCRIPTION
## Summary
- add a `FileChannel`-backed binary range reader abstraction for future large-file refactors
- move `AbstractFile.createInstance()` behind a reader bridge instead of calling `File.readBytes()` directly
- lazy-load raw and ELF binary contents, and stop retaining PE parsing bytes after object construction

## What Changed
- add `BinaryRangeReader` and `FileChannelBinaryRangeReader`
- add `DeferredFileBackedBinaryContent` and a shared loader interface
- sniff binary container headers before deciding how aggressively to read content
- keep `RawFile` and `ElfFile` contents deferred until a view actually needs bytes
- parse `PEFile` with a temporary byte array but avoid keeping that array attached to the object afterward

## Test Coverage
- add unit tests for the range reader bridge and deferred file-backed content helper
- add unit tests for header sniffing and raw lazy-load behavior

## Verification
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew testDebugUnitTest assembleDebug`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of binary file types (ELF, PE, RAW) when opening files.

* **Performance Improvements**
  * Deferred (lazy) binary content loading to reduce memory use for large files.

* **Bug Fixes**
  * Corrected displayed file size in binary details for large files.

* **Tests**
  * Added extensive tests for format detection, lazy loading, range reading, and related UI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->